### PR TITLE
Revert "Bump urllib3 from 1.26.18 to 1.26.19 in /catalog-api/enumerate-products-python in the pip group across 1 directory"

### DIFF
--- a/catalog-api/enumerate-products-python/Pipfile.lock
+++ b/catalog-api/enumerate-products-python/Pipfile.lock
@@ -64,12 +64,12 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
-                "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07",
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"
             ],
             "index": "pypi",
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.19"
+            "version": "==1.26.18"
         }
     },
     "develop": {}


### PR DESCRIPTION
Reverts ruby4406/us-ca-mac#1